### PR TITLE
feat: Replace FormSubmit with Gmail OAuth2 email

### DIFF
--- a/src/pages/Admission/Admission.jsx
+++ b/src/pages/Admission/Admission.jsx
@@ -3,10 +3,10 @@ import { motion } from "framer-motion";
 import { HiOutlineDocumentArrowDown } from "react-icons/hi2";
 import Header from "../../components/Header/Header";
 import styles from "./Admission.module.css";
-import axios from "axios";
 import Swal from "sweetalert2";
 import { fadeUp, inViewProps } from "../../utils/motion";
 import { downloadFile } from "../../utils/download";
+import axiosInstance from "../../api/axiosInstance";
 
 const classOptions = [
   { value: "pre_nursery", label: "Pre Nursery" },
@@ -185,20 +185,16 @@ const Admission = () => {
     if (flag) {
       admissionFormSubmitBtn.disabled = true;
       admissionFormSubmitBtn.innerHTML = "Please Wait..";
-      axios.defaults.headers.post["Content-Type"] = "application/json";
-      axios
-        .post(
-          "https://formsubmit.co/ajax/thegreenschoolinternational@gmail.com",
-          {
-            childname: admissionFormData.childname,
-            fathername: admissionFormData.fathername,
-            whatsappnumber: admissionFormData.whatsappnumber,
-            class: admissionFormData.class,
-            email: admissionFormData.email,
-            address: admissionFormData.address,
-            query: admissionFormData.query,
-          }
-        )
+      axiosInstance
+        .post("send-admission-enquiry", {
+          childname: admissionFormData.childname,
+          fathername: admissionFormData.fathername,
+          whatsappnumber: admissionFormData.whatsappnumber,
+          class: admissionFormData.class,
+          email: admissionFormData.email,
+          address: admissionFormData.address,
+          query: admissionFormData.query,
+        })
         .then(() => {
           Swal.fire({
             icon: "success",

--- a/src/pages/Contact/Contact.jsx
+++ b/src/pages/Contact/Contact.jsx
@@ -7,7 +7,7 @@ import { AiFillPhone } from "react-icons/ai";
 import { BsFillEnvelopeFill } from "react-icons/bs";
 import { HiOutlineMapPin } from "react-icons/hi2";
 import { FaDirections } from "react-icons/fa";
-import axios from "axios";
+import axiosInstance from "../../api/axiosInstance";
 import Swal from "sweetalert2";
 import { fadeUp, inViewProps } from "../../utils/motion";
 
@@ -89,18 +89,14 @@ const Contact = () => {
     if (flag) {
       contactSubmitBtn.disabled = true;
       contactSubmitBtn.innerHTML = "Please Wait..";
-      axios.defaults.headers.post["Content-Type"] = "application/json";
-      axios
-        .post(
-          "https://formsubmit.co/ajax/thegreenschoolinternational@gmail.com",
-          {
-            name: contactData.fname,
-            contact: contactData.contact,
-            email: contactData.email,
-            subject: contactData.subject,
-            message: contactData.message,
-          }
-        )
+      axiosInstance
+        .post("send-contact-message", {
+          name: contactData.fname,
+          contact: contactData.contact,
+          email: contactData.email,
+          subject: contactData.subject,
+          message: contactData.message,
+        })
         .then(() => {
           Swal.fire({
             icon: "success",


### PR DESCRIPTION
## Why

FormSubmit.co (the third-party service used for sending admission and contact form emails) is down — returning HTTP 522 (origin unreachable). This PR removes the FormSubmit dependency and points both forms to our own backend email endpoints.

## What Changed

### `src/pages/Admission/Admission.jsx`
- Removed `axios` import, replaced with shared `axiosInstance`
- Form now POSTs to `api.greenschoolguwahati.com/api/send-admission-enquiry` instead of `formsubmit.co/ajax/...`

### `src/pages/Contact/Contact.jsx`
- Removed `axios` import, replaced with shared `axiosInstance`
- Form now POSTs to `api.greenschoolguwahati.com/api/send-contact-message` instead of `formsubmit.co/ajax/...`

## Setup Required

The backend must be deployed first with Gmail OAuth2 credentials configured. See the backend PR for full setup instructions.

### Server `.env` (on the backend)
```env
GMAIL_CLIENT_ID=<your-client-id>
GMAIL_CLIENT_SECRET=<your-client-secret>
GMAIL_REFRESH_TOKEN=<your-refresh-token>
```

Refer to [backend PR #5](https://github.com/Vedic-Gyan-Foundation/green-school-international-backend/pull/5) for step-by-step instructions on generating these values via Google Cloud Console and OAuth Playground.

## Deploy Order

1. Merge and deploy **backend PR** first → https://github.com/Vedic-Gyan-Foundation/green-school-international-backend/pull/5
2. Then merge and deploy **this frontend PR**